### PR TITLE
Add link to Korean Translation version

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,6 @@ visit our Google Group:
 
 For very specific configuration questions, you may also wish to check Stack
 Overflow to see if other users have posted comments about your configuration.
+
+## Korean translation version of Jupyter Project
+[Korean Version of Installation](https://github.com/ChungJooHo/Jupyter_Kor_doc/)


### PR DESCRIPTION
I add my repo link on README so that people who wants to read it
 translated version of Korean.

As I heared your idea, I made new repo. And I will continue to translate such docs as soon as I can.
 The link I added is a link to my repo, so people who wants to read it can see Korean version.

I will update my repo steadily. Thank you.
